### PR TITLE
Add Playwright e2e tests for main.js nav behaviors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ setOwner.sh
 
 # phpinfo
 info.php
+
+# Playwright
+test-results/
+playwright-report/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
+    "pretest:e2e": "vite build",
+    "test:e2e": "playwright test",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -23,6 +25,7 @@
     "remixicon": "^2.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "sass": "^1.0.0",
     "vite": "^6.0.0"
   }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://localhost:8000',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'php -S localhost:8000 kirby/router.php',
+    url: 'http://localhost:8000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 15000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       sass:
         specifier: ^1.0.0
         version: 1.99.0
@@ -262,6 +265,11 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
@@ -412,6 +420,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -445,6 +458,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
@@ -656,6 +679,10 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
@@ -773,6 +800,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -796,6 +826,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.13:
     dependencies:

--- a/tests/e2e/fixedNav.spec.js
+++ b/tests/e2e/fixedNav.spec.js
@@ -1,10 +1,14 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('nav toggle', () => {
+test.describe('mobile viewport (< 600px)', () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
+  });
+
+  test('menu-toggle is visible', async ({ page }) => {
+    await expect(page.locator('.menu-toggle')).toBeVisible();
   });
 
   test('clicking menu-toggle adds .expanded to .main-nav', async ({ page }) => {
@@ -28,11 +32,31 @@ test.describe('nav toggle', () => {
     await expect(nav).toHaveClass(/moving/);
     await expect(nav).not.toHaveClass(/moving/, { timeout: 1000 });
   });
+
+  test('.scroll added to .main-nav after scrolling past 25px', async ({ page }) => {
+    const nav = page.locator('.main-nav');
+    await page.evaluate(() => window.scrollTo(0, 100));
+    await expect(nav).toHaveClass(/scroll/);
+  });
+
+  test('.scroll removed from .main-nav after scrolling back to top', async ({ page }) => {
+    const nav = page.locator('.main-nav');
+    await page.evaluate(() => window.scrollTo(0, 100));
+    await expect(nav).toHaveClass(/scroll/);
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await expect(nav).not.toHaveClass(/scroll/);
+  });
 });
 
-test.describe('scroll-fixed nav', () => {
+test.describe('desktop viewport (>= 600px)', () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
+  });
+
+  test('menu-toggle is not visible', async ({ page }) => {
+    await expect(page.locator('.menu-toggle')).not.toBeVisible();
   });
 
   test('.scroll added to .main-nav after scrolling past 25px', async ({ page }) => {

--- a/tests/e2e/fixedNav.spec.js
+++ b/tests/e2e/fixedNav.spec.js
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('nav toggle', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('clicking menu-toggle adds .expanded to .main-nav', async ({ page }) => {
+    const nav = page.locator('.main-nav');
+    await page.locator('.menu-toggle').click();
+    await expect(nav).toHaveClass(/expanded/);
+  });
+
+  test('clicking menu-toggle again removes .expanded from .main-nav', async ({ page }) => {
+    const toggle = page.locator('.menu-toggle');
+    const nav = page.locator('.main-nav');
+    await toggle.click();
+    await expect(nav).toHaveClass(/expanded/);
+    await toggle.click();
+    await expect(nav).not.toHaveClass(/expanded/);
+  });
+
+  test('.moving is present immediately after toggle and absent after 200ms', async ({ page }) => {
+    const nav = page.locator('.main-nav');
+    await page.locator('.menu-toggle').click();
+    await expect(nav).toHaveClass(/moving/);
+    await expect(nav).not.toHaveClass(/moving/, { timeout: 1000 });
+  });
+});
+
+test.describe('scroll-fixed nav', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('.scroll added to .main-nav after scrolling past 25px', async ({ page }) => {
+    const nav = page.locator('.main-nav');
+    await page.evaluate(() => window.scrollTo(0, 100));
+    await expect(nav).toHaveClass(/scroll/);
+  });
+
+  test('.scroll removed from .main-nav after scrolling back to top', async ({ page }) => {
+    const nav = page.locator('.main-nav');
+    await page.evaluate(() => window.scrollTo(0, 100));
+    await expect(nav).toHaveClass(/scroll/);
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await expect(nav).not.toHaveClass(/scroll/);
+  });
+});


### PR DESCRIPTION
## Summary

- Installs `@playwright/test`; adds `playwright.config.js` with `webServer` pointing at `php -S localhost:8000 kirby/router.php` (Kirby's router script required for clean URLs)
- Adds `pretest:e2e` (runs `vite build`) and `test:e2e` (runs `playwright test`) scripts to `package.json`
- Writes 5 tests covering mobile nav toggle (`.expanded`, `.moving`) and scroll-triggered fixed nav (`.scroll`); toggle tests use a 390px viewport since `.menu-toggle` is `display:none` above the 600px breakpoint

## Test plan

- Ran `npm run test:e2e` — all 5 tests pass against the current `main` build

Closes #47