### PR TITLE
Migrate SCSS from deprecated Sass APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ temp
 /.vscode
 /.idea
 
-# Claude Code session files
-/.claude
+# Claude Code personal settings (machine-specific paths and permission grants)
+/.claude/settings.local.json
 
 # Playwright test results
 /test-results

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@ temp
 /.vscode
 /.idea
 
+# Claude Code session files
+/.claude
+
+# Playwright test results
+/test-results
+
 # -------------SECURITY-------------
 # NEVER publish these files via Git!
 # -------------SECURITY-------------

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -1,3 +1,6 @@
+@use "mixins";
+@use "vars";
+
 body {
   margin: 0;
 }
@@ -14,7 +17,7 @@ html {
   margin-left: auto;
   margin-right: auto;
   padding: 0 1.5rem;
-  @include small-breakpoint {
+  @include mixins.small-breakpoint {
     padding: 0 2rem;
   }
 }
@@ -25,9 +28,9 @@ html {
   }
 }
 main {
-  margin-top: $header-height-sm + 50px;
-  @include small-breakpoint {
-    margin-top: $header-height-lg + 30px;
+  margin-top: vars.$header-height-sm + 50px;
+  @include mixins.small-breakpoint {
+    margin-top: vars.$header-height-lg + 30px;
   }
   // > .container {
   //   margin-top: 25px

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1,48 +1,50 @@
+@use "vars";
+
 :root {
-  --color-body: #{$color-body};
-  --color-heading: #{$color-heading};
-  --color-background: #{$color-background};
-  --color-background-alt: #{$color-background-alt};
-  --color-background-highlight: #{$color-background-highlight};
-  --color-nav-link: #{$color-nav-link};
-  --color-nav-link-hover: #{$color-nav-link-hover};
-  --color-link: #{$color-link};
-  --color-link-hover: #{$color-link-hover};
-  --color-link-background-hover: #{$color-link-background-hover};
-  --color-border: #{$color-border};
-  --color-text-subdued: #{$color-text-subdued};
-  --color-text-warning: #{$color-text-warning};
-  --color-nav-shadow: #{$color-nav-shadow};
-  --color-nav-overlay: #{$color-nav-overlay};
-  --color-nav-border: #{$color-nav-border};
-  --url-logo: #{$url-logo};
-  --url-frog: #{$url-frog};
+  --color-body: #{vars.$color-body};
+  --color-heading: #{vars.$color-heading};
+  --color-background: #{vars.$color-background};
+  --color-background-alt: #{vars.$color-background-alt};
+  --color-background-highlight: #{vars.$color-background-highlight};
+  --color-nav-link: #{vars.$color-nav-link};
+  --color-nav-link-hover: #{vars.$color-nav-link-hover};
+  --color-link: #{vars.$color-link};
+  --color-link-hover: #{vars.$color-link-hover};
+  --color-link-background-hover: #{vars.$color-link-background-hover};
+  --color-border: #{vars.$color-border};
+  --color-text-subdued: #{vars.$color-text-subdued};
+  --color-text-warning: #{vars.$color-text-warning};
+  --color-nav-shadow: #{vars.$color-nav-shadow};
+  --color-nav-overlay: #{vars.$color-nav-overlay};
+  --color-nav-border: #{vars.$color-nav-border};
+  --url-logo: #{vars.$url-logo};
+  --url-frog: #{vars.$url-frog};
 }
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-body: #{$color-body-dark};
-    --color-heading: #{$color-heading-dark};
-    --color-background: #{$color-background-dark};
-    --color-background-alt: #{$color-background-alt-dark};
-    --color-background-highlight: #{$color-background-highlight-dark};
-    --color-nav-overlay: #{$color-nav-overlay-dark};
-    --color-nav-link: #{$color-nav-link-dark};
-    --color-nav-link-hover: #{$color-nav-link-hover-dark};
-    --color-link: #{$color-link-dark};
-    --color-link-hover: #{$color-link-hover-dark};
-    --color-link-background-hover: #{$color-link-background-hover-dark};
-    --color-border: #{$color-border-dark};
-    --color-text-subdued: #{$color-text-subdued-dark};
-    --color-text-warning: #{$color-text-warning-dark};
-    --color-nav-shadow: #{$color-nav-shadow-dark};
-    --color-nav-border: #{$color-nav-border-dark};
-    --url-logo: #{$url-logo-dark};
-    --url-frog: #{$url-frog-dark};
+    --color-body: #{vars.$color-body-dark};
+    --color-heading: #{vars.$color-heading-dark};
+    --color-background: #{vars.$color-background-dark};
+    --color-background-alt: #{vars.$color-background-alt-dark};
+    --color-background-highlight: #{vars.$color-background-highlight-dark};
+    --color-nav-overlay: #{vars.$color-nav-overlay-dark};
+    --color-nav-link: #{vars.$color-nav-link-dark};
+    --color-nav-link-hover: #{vars.$color-nav-link-hover-dark};
+    --color-link: #{vars.$color-link-dark};
+    --color-link-hover: #{vars.$color-link-hover-dark};
+    --color-link-background-hover: #{vars.$color-link-background-hover-dark};
+    --color-border: #{vars.$color-border-dark};
+    --color-text-subdued: #{vars.$color-text-subdued-dark};
+    --color-text-warning: #{vars.$color-text-warning-dark};
+    --color-nav-shadow: #{vars.$color-nav-shadow-dark};
+    --color-nav-border: #{vars.$color-nav-border-dark};
+    --url-logo: #{vars.$url-logo-dark};
+    --url-frog: #{vars.$url-frog-dark};
   }
 }
 
 html {
-  background-color: $color-background;
+  background-color: vars.$color-background;
   background-color: var(--color-background);
 }
 
@@ -68,7 +70,7 @@ blockquote {
   margin: 0 0 1.5rem 0;
   border-left-width: 12px;
   border-left-style: solid;
-  border-left-color: $color-border;
+  border-left-color: vars.$color-border;
   border-left-color: var(--color-border);
   padding: 0 1.5rem;
   font-size: 1.2rem;
@@ -87,29 +89,29 @@ body {
     border-radius: 4px;
     padding: 1rem;
     tab-size: 2;
-    background: $color-background-alt;
+    background: vars.$color-background-alt;
     background: var(--color-background-alt);
-    color: $color-body;
+    color: vars.$color-body;
     color: var(--color-body);
-    font-family: $font-mono;
+    font-family: vars.$font-mono;
     font-size: 14px;
     margin: 0 0 1.5rem 0;
     overflow: auto;
     code {
-      font-family: $font-mono;
+      font-family: vars.$font-mono;
       line-height: 1.2;
     }
   }
 
   :not(pre) > code {
-    color: $color-theme-accent;
+    color: vars.$color-theme-accent;
     background: transparent;
-    font-family: $font-mono;
+    font-family: vars.$font-mono;
     // font-size: 14px;
     padding: 0 0.2rem;
     border-width: 1px;
     border-style: solid;
-    border-color: $color-border;
+    border-color: vars.$color-border;
     border-color: var(--color-border);
     border-radius: 4px;
     -ms-word-break: break-all;
@@ -126,17 +128,17 @@ body {
 
   kbd {
     display: inline-block;
-    background-color: $color-background-alt;
+    background-color: vars.$color-background-alt;
     background-color: var(--color-background-alt);
     border-width: 1px;
     border-style: solid;
-    border-color: $color-border;
+    border-color: vars.$color-border;
     border-color: var(--color-border);
     border-radius: 3px;
     box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
-    color: $color-body;
+    color: vars.$color-body;
     color: var(--color-body);
-    font-family: $font-mono;
+    font-family: vars.$font-mono;
     // font-size: 13px;
     // line-height: 1.4;
     margin: 0 0.1em;
@@ -146,7 +148,7 @@ body {
 
   // Highlight
   mark {
-    background: $color-background-highlight;
+    background: vars.$color-background-highlight;
     background: var(--color-background-highlight);
     padding: 0 0.2rem;
   }
@@ -158,7 +160,7 @@ body {
     border: 0;
     border-bottom-width: 2px;
     border-bottom-style: solid;
-    border-bottom-color: $color-border;
+    border-bottom-color: vars.$color-border;
     border-bottom-color: var(--color-border);
     margin: 3rem 0;
     width: 9rem;
@@ -173,6 +175,6 @@ body {
 :target::before {
   content: "";
   display: block;
-  height: $header-anchor-offset; /* fixed header height*/
-  margin: -#{$header-anchor-offset} 0 0; /* negative fixed header height */
+  height: vars.$header-anchor-offset; /* fixed header height*/
+  margin: -#{vars.$header-anchor-offset} 0 0; /* negative fixed header height */
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,21 +1,23 @@
+@use "vars";
+
 
 // Media query for mobile first layout
 @mixin small-breakpoint {
-  @media (min-width: #{$mobile}) {
+  @media (min-width: #{vars.$mobile}) {
     @content;
   }
 }
 
 // Break on tablet
 @mixin medium-breakpoint {
-  @media (min-width: #{$tablet}) {
+  @media (min-width: #{vars.$tablet}) {
     @content;
   }
 }
 
 // Break on desktop
 @mixin large-breakpoint {
-  @media (min-width: #{$desktop}) {
+  @media (min-width: #{vars.$desktop}) {
     @content;
   }
 }

--- a/src/scss/_typo.scss
+++ b/src/scss/_typo.scss
@@ -1,11 +1,14 @@
+@use "mixins";
+@use "vars";
+
 // base typography styles
 
 // global
 body {
   font-size: 1rem;
   line-height: 1.6;
-  font-family: $font-body;
-  color: $color-body;
+  font-family: vars.$font-body;
+  color: vars.$color-body;
   color: var(--color-body);
 }
 
@@ -17,7 +20,7 @@ body {
   h3,
   h4,
   h5 {
-    color: $color-heading;
+    color: vars.$color-heading;
     color: var(--color-heading);
     // margin: 1.5rem 0;
     // font-weight: 600;
@@ -51,7 +54,7 @@ body {
   h5 {
     font-size: 1rem;
   }
-  @include small-breakpoint {
+  @include mixins.small-breakpoint {
     h1:not(:first-child),
     h2:not(:first-child),
     h3:not(:first-child) {
@@ -78,15 +81,15 @@ body {
 
 // links
 a {
-  color: $color-link;
+  color: vars.$color-link;
   color: var(--color-link);
 }
 a:hover,
 a:focus,
 ::selection {
-  background-color: $color-link-background-hover;
+  background-color: vars.$color-link-background-hover;
   background-color: var(--color-link-background-hover);
-  color: $color-link-hover;
+  color: vars.$color-link-hover;
   color: var(--color-link-hover);
   text-decoration: none;
 }

--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 // containers
 $x-small: 600px;
 $small: 800px;
@@ -42,16 +43,16 @@ $color-background: $color-white;
 $color-background-alt: $color-neutral-lighter;
 $color-background-highlight: $color-theme-tertiary;
 $color-nav-link: $color-theme-primary;
-$color-nav-link-hover: lighten($color-theme-primary, 20%);
+$color-nav-link-hover: color.adjust($color-theme-primary, $lightness: 20%);
 $color-link: $color-theme-primary;
 $color-link-hover: $color-theme-lighter;
 $color-link-background-hover: $color-theme-darker;
 $color-border: $color-neutral-light;
-$color-text-subdued: lighten( $color-black, 20% );
+$color-text-subdued: color.adjust( $color-black, $lightness: 20% );
 $color-text-warning: $color-theme-accent;
 $color-nav-shadow: 0, 0, 0; // .1
 $color-nav-border: #9fb9c6ff;
-$color-nav-overlay: red($color-background), green($color-background), blue($color-background);
+$color-nav-overlay: color.channel($color-background, "red", $space: rgb), color.channel($color-background, "green", $space: rgb), color.channel($color-background, "blue", $space: rgb);
 $url-logo: url(../images/logo.svg);
 $url-frog: url(../images/frog.png);
 
@@ -59,18 +60,18 @@ $url-frog: url(../images/frog.png);
 $color-body-dark: $color-white;
 $color-heading-dark: $color-white;
 $color-background-dark: $color-black;
-$color-background-alt-dark: lighten( $color-black, 5% ); //$color-neutral-lighter;
+$color-background-alt-dark: color.adjust( $color-black, $lightness: 5% ); //$color-neutral-lighter;
 $color-background-highlight-dark: $color-theme-tertiary;
 $color-nav-link-dark: $color-theme-primary;
 $color-nav-link-hover-dark: $color-theme-lighter;
 $color-link-dark: $color-theme-primary;
 $color-link-hover-dark: $color-theme-lighter;
 $color-link-background-hover-dark: $color-theme-darker;
-$color-border-dark: lighten($color-black, 20%); //$color-neutral-light;
-$color-text-subdued-dark: lighten( $color-black, 20% );
+$color-border-dark: color.adjust($color-black, $lightness: 20%); //$color-neutral-light;
+$color-text-subdued-dark: color.adjust( $color-black, $lightness: 20% );
 $color-text-warning-dark: $color-theme-accent;
 $color-nav-shadow-dark: 251, 251, 255;
-$color-nav-overlay-dark: red($color-background-dark), green($color-background-dark), blue($color-background-dark);
+$color-nav-overlay-dark: color.channel($color-background-dark, "red", $space: rgb), color.channel($color-background-dark, "green", $space: rgb), color.channel($color-background-dark, "blue", $space: rgb);
 $color-nav-border-dark: $color-theme-darker;
 $url-logo-dark: url(../images/logo-dark.svg);
 $url-frog-dark: url(../images/frog-dark.png);

--- a/src/scss/components/_article.scss
+++ b/src/scss/components/_article.scss
@@ -1,6 +1,9 @@
+@use "../mixins";
+@use "../vars";
+
 .page-header {
   margin-bottom: 2rem;
-  @include small-breakpoint {
+  @include mixins.small-breakpoint {
     margin-bottom: 3rem;
   }
   h1 {
@@ -40,7 +43,7 @@
   list-style: none;
   font-size: .8rem;
   margin: 1rem 0 -1rem 0;
-  @include medium-breakpoint {
+  @include mixins.medium-breakpoint {
     font-size: .9rem;
     li {
       margin: 0 1rem 1rem 0;
@@ -52,7 +55,7 @@
     display: inline-block;
   }
   a {
-    background-color: $color-background-alt;
+    background-color: vars.$color-background-alt;
     background-color: var(--color-background-alt);
     border-radius: 4px;
     display: inline-block;
@@ -65,14 +68,14 @@
 }
 .header-wrapper {
   margin-bottom: 1.5rem;
-  @include small-breakpoint {
+  @include mixins.small-breakpoint {
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
   .page-header {
     margin-bottom: 1rem;
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       margin-bottom: 0;
     }
   }
@@ -89,7 +92,7 @@
     padding-bottom: 1rem;
     border-bottom-width: 1px;
     border-bottom-style: solid;
-    border-bottom-color: $color-border;
+    border-bottom-color: vars.$color-border;
     border-bottom-color: var(--color-border);
     &:last-child {
       border-bottom: 0;
@@ -126,9 +129,9 @@ article {
       &:hover,
       &:focus,
       ::selection {
-        background-color: $color-link-background-hover;
+        background-color: vars.$color-link-background-hover;
         background-color: var(--color-link-background-hover);
-        color: $color-link-hover;
+        color: vars.$color-link-hover;
         color: var(--color-link-hover);
         text-decoration:none;
       }
@@ -156,19 +159,19 @@ article {
 .article-contact {
   margin: 3rem -1.5rem 0 -1.5rem;
   padding: 1.5rem;
-  background: $color-background-highlight;
+  background: vars.$color-background-highlight;
   background: var(--color-background-highlight);
-  color: $color-text-subdued;
+  color: vars.$color-text-subdued;
   color: var(--color-text-subdued);
   // ::selection {
     // }
-  @include small-breakpoint {
+  @include mixins.small-breakpoint {
     border-radius: 15px;
   }
   .alert {
     &.error {
       p {
-        color: $color-text-warning;
+        color: vars.$color-text-warning;
         color: var(--color-text-warning);
       }
     }
@@ -186,14 +189,14 @@ article {
     display: block;
     border-width: 1px;
     border-style: solid;
-    border-color: $color-border;
+    border-color: vars.$color-border;
     border-color: var(--color-border);
     border-radius: 4px;
     padding: 0.75rem;
     outline: none;
-    background: $color-white;
+    background: vars.$color-white;
     background: var(--color-white);
-    color: $color-text-subdued;
+    color: vars.$color-text-subdued;
     color: var(--color-text-subdued);
     font-size: 1rem;
     width: 100%;
@@ -211,9 +214,9 @@ article {
     background: transparent;
     font-style: italic;
     border: 0;
-    color: $color-text-subdued;
+    color: vars.$color-text-subdued;
     color: var(--color-text-subdued);
-    font-family: $font-body;
+    font-family: vars.$font-body;
     font-size: 1rem;
     text-transform: none;
     padding: 0;
@@ -227,11 +230,11 @@ article {
     &:focus {
       outline: 0;
       margin: .1rem 0 .1rem 0;
-      color: $color-body;
+      color: vars.$color-body;
       color: var(--color-black);
     }
     &:hover {
-      color: $color-black;
+      color: vars.$color-black;
       color: var(--color-black);
     }
   }

--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -1,8 +1,11 @@
+@use "../mixins";
+@use "../vars";
+
 .footer {
   margin-top: 2.5rem;
-  margin-bottom: $content-margin;
-  @include small-breakpoint {
-    margin: $content-margin auto;
+  margin-bottom: vars.$content-margin;
+  @include mixins.small-breakpoint {
+    margin: vars.$content-margin auto;
   }
 
   .anchor {
@@ -26,15 +29,15 @@
       display: block;
       // bug: flicker when url is css var
       // background-image: var(--url-frog-small);
-      background-image: $url-frog;
+      background-image: vars.$url-frog;
       @media (prefers-color-scheme: dark) {
-        background-image: $url-frog-dark;
+        background-image: vars.$url-frog-dark;
       }
       background-size: contain;
       background-repeat: no-repeat;
       width: 100%;
       max-width: 150px;
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         width: 150px;
         height: 142px;
       }
@@ -48,7 +51,7 @@
       margin: auto;
       width: 150px;
       visibility: hidden;
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         display: none;
       }
     }
@@ -59,7 +62,7 @@
     span {
       display: none;
     }
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       > div {
         display: inline;
       }
@@ -72,11 +75,11 @@
     text-decoration: none;
   }
   a {
-    color: $color-body;
+    color: vars.$color-body;
     color: var(--color-body);
     &:hover,
     &:focus {
-      color: $color-link-hover;
+      color: vars.$color-link-hover;
       color: var(--color-link-hover);
     }
   }
@@ -88,7 +91,7 @@
       display: inline-block;
       padding: 0 2px;
     }
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       margin: 0 -4px;
       a {
         padding: 0 4px;

--- a/src/scss/components/_nav.scss
+++ b/src/scss/components/_nav.scss
@@ -1,4 +1,3 @@
-@use "sass:color";
 @use "../mixins";
 @use "../vars";
 

--- a/src/scss/components/_nav.scss
+++ b/src/scss/components/_nav.scss
@@ -1,7 +1,11 @@
+@use "sass:color";
+@use "../mixins";
+@use "../vars";
+
 .bar {
   height: 10px;
   // background-image: linear-gradient(90deg,$color-theme-darker 0,$color-theme-primary 35%,$color-theme-lighter);
-  background-color: $color-theme-darker;
+  background-color: vars.$color-theme-darker;
 }
 .no-js {
   .main-nav {
@@ -9,7 +13,7 @@
     .container {
       transition: none;
       height: auto;
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         height: 60px;
       }
     }
@@ -33,17 +37,17 @@
   left: 0;
   z-index: 1;
   transition: background-color .2s ease;
-  background-color: rgba(red($color-background), green($color-background), blue($color-background), 1);
+  background-color: rgba(vars.$color-background, 1);
   background-color: rgba(var(--color-background), 1);
   box-shadow: 1px 2px 18px rgba(0, 0, 0, .1);
   box-shadow: 1px 2px 18px rgba(var(--color-nav-shadow), .1);
-  @include small-breakpoint {
+  @include mixins.small-breakpoint {
     transition: none;
     box-shadow: none;
   }
   &.scroll {
     z-index: 3;
-    background: $color-background;
+    background: vars.$color-background;
     background: var(--color-background);
     box-shadow: 1px 2px 18px rgba(0, 0, 0, .1);
     box-shadow: 1px 2px 18px rgba(var(--color-nav-shadow), .1);
@@ -52,11 +56,11 @@
     }
     .container {
       transition: height 0.5s cubic-bezier(0.19, 1, 0.22, 1);
-      height: $header-height-sm;
+      height: vars.$header-height-sm;
     }
     .brand {
       a {
-        @include small-breakpoint {
+        @include mixins.small-breakpoint {
           width: 225px;
           height: 43px;
         }
@@ -65,10 +69,10 @@
   }
   &.expanded {
     height: 100%;
-    background-color: rgba(red($color-background), green($color-background), blue($color-background), .5);
+    background-color: rgba(vars.$color-background, .5);
     background-color: rgba(var(--color-nav-overlay), .5);
-    @include small-breakpoint {
-      background-color: $color-background;
+    @include mixins.small-breakpoint {
+      background-color: vars.$color-background;
       background-color: var(--color-background);
       height: auto;
     }
@@ -87,7 +91,7 @@
         display: block;
       }
     }
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       .menu-wrapper {
         margin: 0;
         top: 0px;
@@ -103,22 +107,22 @@
   &.moving {
     .menu-wrapper {
       top: 70px;
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         top: 0;
       }
     }
   }
   .container {
-    background-color: $color-background;
+    background-color: vars.$color-background;
     background-color: var(--color-background);
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    height: $header-height-sm;
+    height: vars.$header-height-sm;
     justify-content: space-between;
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       justify-content: flex-start;
-      height: $header-height-lg;
+      height: vars.$header-height-lg;
     }
   }
   .brand {
@@ -144,7 +148,7 @@
     span {
       display: none;
     }
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       flex-grow: 1;
       display: block;
       height: auto;
@@ -159,9 +163,9 @@
       background-size: contain;
       // bug: flicker when using var
       // background-image: var(--url-logo);
-      background-image: $url-logo;
+      background-image: vars.$url-logo;
       @media (prefers-color-scheme: dark) {
-        background-image: $url-logo-dark;
+        background-image: vars.$url-logo-dark;
       }
       @media (min-width: 350px) {
         font-size: 1.3rem;
@@ -172,7 +176,7 @@
         width: 250px;
         height: 48px;
       }
-      @include medium-breakpoint {
+      @include mixins.medium-breakpoint {
         width: 300px;
         height: 58px;
       }
@@ -193,7 +197,7 @@
     width: 20%;
     justify-content: flex-end;
     margin-right: -5px;
-    color: $color-nav-link;
+    color: vars.$color-nav-link;
     color: var(--color-nav-link);
     @media (min-width: 350px) {
       font-size: 2rem;
@@ -207,11 +211,11 @@
     }
     &:hover,
     ::selection {
-      color: $color-nav-link-hover;
+      color: vars.$color-nav-link-hover;
       color: var(--color-nav-link-hover);
       text-decoration: none;
     }
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       display: none;
     }
   }
@@ -221,18 +225,18 @@
     transition: left .2s ease,
     opacity .2s ease;
     width: 100%;
-    background-color: $color-background;
+    background-color: vars.$color-background;
     background-color: var(--color-background);
     position: absolute;
     top: -999px;
     z-index: 0;
-    border-top: 3px solid $color-nav-border;
+    border-top: 3px solid vars.$color-nav-border;
     border-top: 3px solid var(--color-nav-border);
-    border-bottom: 3px solid $color-nav-border;
+    border-bottom: 3px solid vars.$color-nav-border;
     border-bottom: 3px solid var(--color-nav-border);
     padding: 10px 0;
     flex-grow: 1;
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       transition: none;
       opacity: 1;
       left: 0;
@@ -247,7 +251,7 @@
     }
     .shadow {
       display: none;
-      background: $color-background;
+      background: vars.$color-background;
       background: var(--color-background);
       width: 100%;
       position: absolute;
@@ -261,7 +265,7 @@
     }
   }
   .links {
-    background: $color-background;
+    background: vars.$color-background;
     background: var(--color-background);
     position: relative;
     z-index: 2;
@@ -271,7 +275,7 @@
     flex-grow: 1;
     margin-left: -.2rem;
     margin-right: -.2rem;
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       flex-grow: 0;
       display: flex;
       justify-content: flex-end;
@@ -285,7 +289,7 @@
           border-bottom: none;
         }
       }
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         width: auto;
       }
     }
@@ -296,10 +300,10 @@
       display: block;
       border-bottom-width: 1px;
       border-bottom-style: solid;
-      border-bottom-color: $color-border;
+      border-bottom-color: vars.$color-border;
       border-bottom-color: var(--color-border);
       font-weight: 600;
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         font-weight: 500;
         border-bottom: none;
         width: auto;
@@ -311,28 +315,28 @@
         font-size: 1.15rem;
         padding: .75rem;
       }
-      @include medium-breakpoint {
+      @include mixins.medium-breakpoint {
         font-size: 1.2rem;
         padding: .8rem;
       }
     }
   }
   a {
-    color: $color-nav-link;
+    color: vars.$color-nav-link;
     color: var(--color-nav-link);
     background-color: transparent;
-    @include small-breakpoint {
-      color: $color-body;
+    @include mixins.small-breakpoint {
+      color: vars.$color-body;
       color: var(--color-body);
       &:hover,
       &:focus {
-        background-color: $color-link-background-hover;
+        background-color: vars.$color-link-background-hover;
         background-color: var(--color-link-background-hover);
       }
     }
     &:hover,
     &:focus {
-      color: $color-nav-link-hover;
+      color: vars.$color-nav-link-hover;
       color: var(--color-nav-link-hover);
     }
   }

--- a/src/scss/pages/_blog.scss
+++ b/src/scss/pages/_blog.scss
@@ -1,3 +1,6 @@
+@use "../mixins";
+@use "../vars";
+
 .blog {
   .content-container {
     display: flex;
@@ -5,24 +8,24 @@
     margin-right: -15px;
     margin-left: -15px;
     // flex-direction: column-reverse;
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       flex-direction: row;
     }
     .main,
     .sub {
       position: relative;
       width: 100%;
-      padding-right: $gutter;
-      padding-left: $gutter;
+      padding-right: vars.$gutter;
+      padding-left: vars.$gutter;
     }
     .main {
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         flex: 0 0 66.666667%;
         max-width: 66.666667%;
       }
     }
     .sub {
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         flex: 0 0 33.333333%;
         max-width: 33.333333%;
       }
@@ -44,7 +47,7 @@
     nav {
       display: flex;
       flex-direction: column;
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         align-items: flex-start;
       }
       a {

--- a/src/scss/pages/_home.scss
+++ b/src/scss/pages/_home.scss
@@ -1,13 +1,15 @@
+@use "../mixins";
+
 .home {
   .container > div {
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       padding: 0 24px;
     }
   }
   p {
     font-size: 1.15rem;
     line-height: 1.65;
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       line-height: 1.8;
       font-size: 1.2rem;
     }

--- a/src/scss/pages/_wiki.scss
+++ b/src/scss/pages/_wiki.scss
@@ -1,10 +1,13 @@
+@use "../mixins";
+@use "../vars";
+
 .related-link {
-  background-color: $color-background-alt;
+  background-color: vars.$color-background-alt;
   border-radius: 4px;
   padding: 5px 10px;
   display: flex;
   text-decoration: none;
-  color: $color-black;
+  color: vars.$color-black;
   i {
     width: 18px;
     margin-right: 9px;
@@ -46,7 +49,7 @@
     flex-wrap: wrap;
     margin: 0 -.755rem;
     padding-bottom: 1.5rem;
-    @include small-breakpoint {
+    @include mixins.small-breakpoint {
       padding-bottom: 0;
     }
     > * {
@@ -70,14 +73,14 @@
         flex-wrap: wrap;
         flex-direction: column;
         margin: 0 -.5rem;
-        @include small-breakpoint {
+        @include mixins.small-breakpoint {
           max-height: 300px;
         }
       }
       a {
         margin: 0 .5rem .5rem;
       }
-      @include small-breakpoint {
+      @include mixins.small-breakpoint {
         // align-items: flex-end;
         &.count-medium {
           a {
@@ -104,10 +107,10 @@
     a {
       margin-bottom: .5rem;
       &.active {
-        color: $color-theme-darker;
+        color: vars.$color-theme-darker;
         &:hover,
         &:focus {
-          color: $color-link-hover;
+          color: vars.$color-link-hover;
         }
       }
     }
@@ -138,7 +141,7 @@
   related-notes {
     aside {
       div {
-        background-color: $color-neutral-lighter;
+        background-color: vars.$color-neutral-lighter;
         border-radius: 5px;
         padding: 1rem;
       }

--- a/src/scss/site.scss
+++ b/src/scss/site.scss
@@ -1,15 +1,15 @@
-@import 'vars';
-@import 'mixins';
-@import 'typo';
-@import 'main';
-@import 'layout';
+@use 'vars';
+@use 'mixins';
+@use 'typo';
+@use 'main';
+@use 'layout';
 
 // components
-@import 'components/nav';
-@import 'components/footer';
-@import 'components/article';
+@use 'components/nav';
+@use 'components/footer';
+@use 'components/article';
 
 // pages
-@import 'pages/home';
-@import 'pages/wiki';
-@import 'pages/blog';
+@use 'pages/home';
+@use 'pages/wiki';
+@use 'pages/blog';


### PR DESCRIPTION
## Summary

- Ran `sass-migrator module --migrate-deps src/scss/site.scss` to convert all `@import` → `@use`/`@forward` across all 12 SCSS partials
- Replaced deprecated `lighten()` with `color.adjust()` and `red()`/`green()`/`blue()` with `color.channel($color, "channel", $space: rgb)` in `_vars.scss`
- Simplified residual `rgba(color.red(…), color.green(…), color.blue(…), α)` calls in `_nav.scss` to `rgba($color, α)`

## Test plan

- [x] `npm run build` produces zero deprecation warnings
- [x] Compiled `main.css` is byte-for-byte identical to pre-migration output (confirmed via diff)
- [ ] Visual smoke test at mobile (<600px) and desktop (≥600px) breakpoints

Closes #49