### PR TITLE
Set up git-based deployment

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Pushes local commits to GitHub, then triggers git pull on the server.
+# Requires .sync/config.src — see .sync/readme.md for setup.
+DIR="$(dirname "$(readlink -f "$0")")"
+CONFIG="$DIR/../.sync/config.src"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "Missing .sync/config.src — see .sync/readme.md for setup"
+  exit 1
+fi
+
+source "$CONFIG"
+
+# Parse user@host and path from _remote (rsync format: user@host:path/)
+_host="${_remote%%:*}"
+_path="~/${_remote##*:}"
+_path="${_path%/}"
+
+echo "→ Pushing to GitHub..."
+git push || exit 1
+
+echo "→ Deploying to $_host..."
+ssh -i "$_key" "$_host" "git -C $_path pull"


### PR DESCRIPTION
## Summary
- Add `tools/deploy.sh` — pushes to GitHub then SSHs to server to run `git pull`
- Sources `.sync/config.src` for SSH credentials (to be relocated when `.sync/` is retired in Stage 4)

## Test plan
- [x] `./tools/deploy.sh` runs successfully end-to-end

Refs #41